### PR TITLE
fix 香港节点快手解析出现404

### DIFF
--- a/parser/kuaishou.py
+++ b/parser/kuaishou.py
@@ -35,7 +35,7 @@ class KuaiShou(BaseParser):
         async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(
                 location_url,
-                headers=share_response.request.headers,
+                headers=share_response.headers,
                 cookies=share_response.cookies,
             )
 


### PR DESCRIPTION
使用国内ip能正确解析出视频内容。但是使用香港的服务器或节点解析时会出现解析错误：failed to parse video JSON info from HTML
查看解析出来的网页内容
![屏幕截图 2024-12-09 015914](https://github.com/user-attachments/assets/b4f3950c-305a-4729-b30e-aaed4a32fe55)
排查错误中发现是headers的问题，修改后重新解析问题解决
![image](https://github.com/user-attachments/assets/f1d07789-3334-4d99-a549-35919312cc85)
