### PR TITLE
Fix crash when share URL input does not contain a URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,14 @@ async def read_item(request: Request):
 @app.get("/video/share/url/parse", dependencies=get_auth_dependency())
 async def share_url_parse(url: str):
     url_reg = re.compile(r"http[s]?:\/\/[\w.-]+[\w\/-]*[\w.-]*\??[\w=&:\-\+\%]*[/]*")
-    video_share_url = url_reg.search(url).group()
+    matched_url = url_reg.search(url)
+    if matched_url is None:
+        return {
+            "code": 400,
+            "msg": "未检测到有效的分享链接",
+        }
+
+    video_share_url = matched_url.group()
 
     try:
         video_info = await parse_video_share_url(video_share_url)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ mcp.mount_http()
 
 templates = Jinja2Templates(directory="templates")
 
+URL_REG = re.compile(r"http[s]?:\/\/[\w.-]+[\w\/-]*[\w.-]*\??[\w=&:\-\+\%]*[/]*")
+
 
 def get_auth_dependency() -> list[Depends]:
     """
@@ -65,8 +67,7 @@ async def read_item(request: Request):
 
 @app.get("/video/share/url/parse", dependencies=get_auth_dependency())
 async def share_url_parse(url: str):
-    url_reg = re.compile(r"http[s]?:\/\/[\w.-]+[\w\/-]*[\w.-]*\??[\w=&:\-\+\%]*[/]*")
-    matched_url = url_reg.search(url)
+    matched_url = URL_REG.search(url)
     if matched_url is None:
         return {
             "code": 400,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,3 +11,23 @@ def test_share_url_parse_returns_400_when_no_url_found():
 
     assert response.status_code == 200
     assert response.json() == {"code": 400, "msg": "未检测到有效的分享链接"}
+
+
+def test_share_url_parse_returns_400_for_empty_string():
+    response = client.get("/video/share/url/parse", params={"url": ""})
+
+    assert response.status_code == 200
+    assert response.json() == {"code": 400, "msg": "未检测到有效的分享链接"}
+
+
+def test_share_url_parse_returns_400_for_partial_url_without_scheme():
+    response = client.get("/video/share/url/parse", params={"url": "example.com/video/123"})
+
+    assert response.status_code == 200
+    assert response.json() == {"code": 400, "msg": "未检测到有效的分享链接"}
+
+
+def test_share_url_parse_returns_422_when_url_param_missing():
+    response = client.get("/video/share/url/parse")
+
+    assert response.status_code == 422

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_share_url_parse_returns_400_when_no_url_found():
+    response = client.get("/video/share/url/parse", params={"url": "这不是链接"})
+
+    assert response.status_code == 200
+    assert response.json() == {"code": 400, "msg": "未检测到有效的分享链接"}


### PR DESCRIPTION
### Motivation
- Prevent `/video/share/url/parse` from raising an `AttributeError` when the provided `url` string does not contain a valid URL that matches the regex.
- Provide a clear, structured error response instead of letting the endpoint crash on invalid user input.

### Description
- Update `main.py` `share_url_parse` to store `url_reg.search(url)` in `matched_url` and return a JSON error payload when it is `None` instead of calling `.group()` on `None`.
- The handler now returns `{"code": 400, "msg": "未检测到有效的分享链接"}` when no URL is detected in the input.
- Add `tests/test_main.py` with a test that requests `/video/share/url/parse` using a non-URL string and asserts the error payload is returned.

### Testing
- Ran `pytest -q` and all tests passed (`11 passed`, with 2 warnings about dependencies), including the new API test in `tests/test_main.py`.
- The new test `test_share_url_parse_returns_400_when_no_url_found` passed and verifies the invalid-input path returns the expected payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12aaa34bc832baedead90c79f4fad)