### PR TITLE
fix(douyin): 适配抖音页面改版，恢复视频与图文解析

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ web = [
     "jinja2>=3.1",
     "python-multipart>=0.0.20",
     "fastapi-mcp>=0.4",
+    "mcp>=1.12.0,<2.0.0",
 ]
 cli = [
     "typer>=0.12",

--- a/src/parse_video_py/parser/douyin.py
+++ b/src/parse_video_py/parser/douyin.py
@@ -33,20 +33,18 @@ class DouYin(BaseParser):
         else:
             raise ValueError(f"Douyin not support this host: {host}")
 
-        async with create_async_client(follow_redirects=True) as client:
-            response = await client.get(share_url, headers=self.get_default_headers())
-            response.raise_for_status()
-
-        # 检查是否是图集内容
-        is_note = self._is_note_content(response.text, share_url)
-
-        json_data = None
-        if is_note:
-            # 如果是图集，使用专门的API获取数据
-            json_data = await self._get_slides_info(video_id)
+        # 优先通过专用接口获取视频/图集详情。该接口当前同时返回
+        # aweme_details，不再依赖页面 SSR 中的 videoInfoRes 字段。
+        json_data = await self._get_slides_info(video_id)
 
         if not json_data:
-            # 如果专用API失败或者不是图集，使用标准解析方式
+            # 专用接口失败时，回退到旧的 HTML SSR 解析方式
+            async with create_async_client(follow_redirects=True) as client:
+                response = await client.get(
+                    share_url, headers=self.get_default_headers()
+                )
+                response.raise_for_status()
+
             pattern = re.compile(
                 pattern=r"window\._ROUTER_DATA\s*=\s*(.*?)</script>",
                 flags=re.DOTALL,
@@ -276,20 +274,11 @@ class DouYin(BaseParser):
         return False
 
     async def _get_slides_info(self, video_id: str) -> dict:
-        """获取图集的详细信息，包括Live Photo"""
+        """获取抖音视频或图集的详细信息，包括 Live Photo"""
         try:
-            # 生成web_id和a_bogus参数
-            web_id = "75" + self._generate_fixed_length_numeric_id(15)
-            a_bogus = self._rand_seq(64)
-
             api_url = (
                 f"https://www.iesdouyin.com/web/api/v2/aweme/slidesinfo/"
-                f"?reflow_source=reflow_page"
-                f"&web_id={web_id}"
-                f"&device_id={web_id}"
-                f"&aweme_ids=%5B{video_id}%5D"
-                f"&request_source=200"
-                f"&a_bogus={a_bogus}"
+                f"?aweme_ids=%5B{video_id}%5D"
             )
 
             async with create_async_client() as client:

--- a/src/parse_video_py/parser/douyin.py
+++ b/src/parse_video_py/parser/douyin.py
@@ -275,21 +275,33 @@ class DouYin(BaseParser):
 
     async def _get_slides_info(self, video_id: str) -> dict:
         """获取抖音视频或图集的详细信息，包括 Live Photo"""
-        try:
-            api_url = (
+        # 普通视频不带 request_source 可以拿到数据；
+        # 图文（note）需要带 request_source=200。这里逐个尝试。
+        api_urls = [
+            (
                 f"https://www.iesdouyin.com/web/api/v2/aweme/slidesinfo/"
                 f"?aweme_ids=%5B{video_id}%5D"
-            )
+            ),
+            (
+                f"https://www.iesdouyin.com/web/api/v2/aweme/slidesinfo/"
+                f"?aweme_ids=%5B{video_id}%5D&request_source=200"
+            ),
+        ]
 
-            async with create_async_client() as client:
-                response = await client.get(api_url, headers=self.get_default_headers())
-                response.raise_for_status()
+        async with create_async_client() as client:
+            for api_url in api_urls:
+                try:
+                    response = await client.get(
+                        api_url, headers=self.get_default_headers()
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                except Exception:
+                    continue
+                if data and data.get("aweme_details"):
+                    return data
 
-            data = response.json()
-            return data if data.get("aweme_details") else None
-
-        except Exception:
-            return None
+        return None
 
     def _generate_fixed_length_numeric_id(self, length: int) -> str:
         """生成固定位数的随机数字ID"""


### PR DESCRIPTION
## 问题

抖音在 2026-08 改版后，SSR 页面不再返回 `videoInfoRes`，所有抖音链接解析都报：

```json
{"code":500,"msg":"'videoInfoRes'"}
```

相关 issue：#93、#94

## 原因

1. `window._ROUTER_DATA.loaderData["video_(id)/page"]` 已不再包含 `videoInfoRes`，旧解析逻辑直接触发 KeyError；
2. 图文分享短链会跳转到 `/share/slides/`，且 `slidesinfo` 接口需要 `request_source=200` 才能返回数据；
3. 旧代码请求 `slidesinfo` 时携带随机 `a_bogus`，当前抖音会返回空响应。

## 改动

- `src/parse_video_py/parser/douyin.py`：不再依赖 SSR 的 `videoInfoRes`，优先使用 `slidesinfo` 接口。普通视频使用 `aweme_ids=[id]`，图文使用 `aweme_ids=[id]&request_source=200`，两者都失败时再回退到 HTML 解析。
- `pyproject.toml`：固定 `mcp>=1.12.0,<2.0.0`，避免 `fastapi-mcp 0.4.0` 与 `mcp 2.x` 不兼容导致 Web 服务无法启动。

## 验证

- 普通视频短链：解析成功，返回视频地址、封面、作者。
- 图文短链（`/share/slides/`）：解析成功，返回 3 张图片。
- FastAPI 接口 `/video/share/url/parse` 返回 `{"code":200,"msg":"解析成功"}`。

Closes #93
Closes #94